### PR TITLE
fix: replace first name arrow with space

### DIFF
--- a/src/Parser/PassportMrzParser.php
+++ b/src/Parser/PassportMrzParser.php
@@ -107,7 +107,7 @@ class PassportMrzParser implements ParserInterface
      */
     protected function getFirstName(): ?string
     {
-        return isset($this->nameString[1]) ? chop($this->nameString[1], "<") : null;
+        return isset($this->nameString[1]) ? str_replace('<', ' ', chop($this->nameString[1], "<")) : null;
     }
 
     /**


### PR DESCRIPTION
This PR resolves the first name arrow and space replacement issue.

Resolve #1 
![image](https://user-images.githubusercontent.com/30468274/176106620-7e890707-e58a-4c0c-9d59-cf3a61e78ab6.png)
